### PR TITLE
Fix shell output for 'verifying partition creation'

### DIFF
--- a/docs/gpu-partitioning/mi300x/quick-start-guide.rst
+++ b/docs/gpu-partitioning/mi300x/quick-start-guide.rst
@@ -1,7 +1,7 @@
 Quick Start Guide to Partitioning MI300X GPUs
 ==============================================
 
-This guide serves as a practical and technically detailed reference for configuring compute and memory partitioning on AMD Instinct™ MI300X GPUs using the `amd-smi` utility. Partitioning is a key feature that enables system administrators, developers, and data center operators to dynamically subdivide a single MI300X GPU into multiple logical devices—each with its own dedicated compute and memory resources. This empowers users to maximize resource utilization, improve workload isolation, and optimize performance for diverse AI, HPC, and multi-tenant cloud environments.
+This guide serves as a practical and technically detailed reference for configuring compute and memory partitioning on AMD Instinct™ MI300X GPUs using the ``amd-smi`` utility. Partitioning is a key feature that enables system administrators, developers, and data center operators to dynamically subdivide a single MI300X GPU into multiple logical devices—each with its own dedicated compute and memory resources. This empowers users to maximize resource utilization, improve workload isolation, and optimize performance for diverse AI, HPC, and multi-tenant cloud environments.
 
 Partitioning on MI300X involves two dimensions:
 
@@ -167,8 +167,6 @@ b. **Set memory partitioning mode to NPS4:**
 
     - After setting the partitioning modes, you can verify the partition creation using the ``amd-smi`` tool.
     - The command will display the current partitioning status of the GPUs, including compute and memory partitioning modes.
-
-To confirm active partitioning state:
 
 Use ``amd-smi`` to confirm active partition states:
 

--- a/docs/gpu-partitioning/mi300x/quick-start-guide.rst
+++ b/docs/gpu-partitioning/mi300x/quick-start-guide.rst
@@ -17,8 +17,8 @@ Whether you are deploying MI300X GPUs for large-scale language model inference, 
 
 1. Creating CPX/NPS4 Partition
 -------------------------------
-    
-    - This section describes how to create a CPX/NPS4 partition on MI300X GPUs using the `amd-smi` tool.
+
+    - This section describes how to create a CPX/NPS4 partition on MI300X GPUs using the ``amd-smi`` tool.
     - The partitioning process involves setting compute and memory partitioning modes to CPX and NPS4, respectively.
     - The example below demonstrates how to set up a CPX/NPS4 partition on all GPUs in the system. 
 
@@ -26,19 +26,18 @@ To create a CPX/NPS4 partition:
 
 a. **Set compute partitioning mode to CPX:**
 
-
    .. tab-set::
 
       .. tab-item:: Compute Partition Command
 
-         .. code-block:: shell-session
+         .. code-block:: shell
 
             # Set compute partition mode
-            sudo amd-smi set --gpu all --compute-partition CPX    
+            sudo amd-smi set --gpu all --compute-partition CPX
 
       .. tab-item:: Shell output
 
-         ::
+         .. code-block:: shell-session
 
             GPU: 0
                 ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
@@ -70,7 +69,7 @@ a. **Set compute partitioning mode to CPX:**
 
    When switching from **SPX+NPS1** to **CPX+NPS4**, setting the memory partition to **NPS4** will automatically transition the compute partition to **CPX**. You can skip the explicit CPX compute mode step, setting **NPS4** alone is sufficient to configure a valid **CPX+NPS4** partition.
 
-   .. code-block:: shell-session
+   .. code-block:: shell
 
       sudo amd-smi set --memory-partition NPS4
 
@@ -83,77 +82,78 @@ b. **Set memory partitioning mode to NPS4:**
 
       .. tab-item:: Memory Partition Command
 
-         .. code-block:: shell-session
+         .. code-block:: shell
 
             # Set memory partition mode
-            sudo amd-smi set --memory-partition NPS4  
+            sudo amd-smi set --memory-partition NPS4
 
       .. tab-item:: Shell output
 
-         ::
-            
-          ****** WARNING ******
+         .. code-block:: shell-session
 
-          Setting Dynamic Memory (NPS) partition modes require users to quit all GPU workloads.
-          AMD SMI will then attempt to change memory (NPS) partition mode.
-          Upon a successful set, AMD SMI will then initiate an action to restart AMD GPU driver.
-          This action will change all GPU's in the hive to the requested memory (NPS) partition mode.
+             ****** WARNING ******
 
-          Please use this utility with caution.
+             Setting Dynamic Memory (NPS) partition modes require users to quit all GPU workloads.
+             AMD SMI will then attempt to change memory (NPS) partition mode.
+             Upon a successful set, AMD SMI will then initiate an action to restart AMD GPU driver.
+             This action will change all GPU's in the hive to the requested memory (NPS) partition mode.
 
-          Do you accept these terms? [Y/N] Y
+             Please use this utility with caution.
 
-          Trying again - Updating memory partition for gpu 0: [██████████████..........................] 50/140 secs remain
+             Do you accept these terms? [Y/N] Y
 
-          GPU: 0
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             Trying again - Updating memory partition for gpu 0: [██████████████..........................] 50/140 secs remain
 
-          GPU: 1
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 0
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 2
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 1
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 3
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 2
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 4
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 3
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 5
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 4
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 6
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 5
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 7
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 6
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 8
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 7
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 9
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 8
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 10
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 9
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 11
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 10
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 12
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 11
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 13
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 12
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          GPU: 14
-            MEMORY_PARTITION: Successfully set memory partition to NPS4
+             GPU: 13
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
 
-          OSError: [Errno 24] Too many open files
+             GPU: 14
+               MEMORY_PARTITION: Successfully set memory partition to NPS4
+
+             OSError: [Errno 24] Too many open files
 
 .. note::
-   The above `amd-smi` command to set the partition mode may not show memory partition status for all GPUs. This is a known tool issue.
+
+   The above ``amd-smi`` command to set the partition mode may not show memory partition status for all GPUs. This is a known tool issue.
    Despite the error, the partition mode will be set correctly across all GPUs.
 
 - The command will set the following:
@@ -164,98 +164,98 @@ b. **Set memory partitioning mode to NPS4:**
 
 2. Verifying Partition Creation
 ----------------------------------
-    
-    - After setting the partitioning modes, you can verify the partition creation using the `amd-smi` tool.
+
+    - After setting the partitioning modes, you can verify the partition creation using the ``amd-smi`` tool.
     - The command will display the current partitioning status of the GPUs, including compute and memory partitioning modes.
 
 To confirm active partitioning state:
 
-Use `amd-smi` to confirm active partition states:
+Use ``amd-smi`` to confirm active partition states:
 
-   .. tab-set::
+.. tab-set::
 
-      .. tab-item:: Command
+   .. tab-item:: Command
 
-         .. code-block:: shell-session
+      .. code-block:: shell
 
-            # Check partitioning status
-            amd-smi static --partition
+         # Check partitioning status
+         amd-smi static --partition
 
-      .. tab-item:: Shell output
+   .. tab-item:: Shell output
 
-         .. code-block:: shell-session
+      .. code-block:: shell-session
 
-            GPU: 0
-                PARTITION:
-                    ACCELERATOR_PARTITION: CPX
-                    MEMORY_PARTITION: NPS1
-                    PARTITION_ID: 0
+         GPU: 0
+             PARTITION:
+                 ACCELERATOR_PARTITION: CPX
+                 MEMORY_PARTITION: NPS1
+                 PARTITION_ID: 0
 
-            GPU: 1
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 1
+         GPU: 1
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 1
 
-            GPU: 2
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 2
+         GPU: 2
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 2
 
-            GPU: 3
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 3
+         GPU: 3
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 3
 
-            GPU: 4
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 4
+         GPU: 4
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 4
 
-            GPU: 5
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 5
+         GPU: 5
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 5
 
-            GPU: 6
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 6
+         GPU: 6
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 6
 
-            GPU: 7
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 7
+         GPU: 7
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 7
 
-            GPU: 8
-                PARTITION:
-                    ACCELERATOR_PARTITION: CPX
-                    MEMORY_PARTITION: NPS1
-                    PARTITION_ID: 0
+         GPU: 8
+             PARTITION:
+                 ACCELERATOR_PARTITION: CPX
+                 MEMORY_PARTITION: NPS1
+                 PARTITION_ID: 0
 
-            GPU: 9
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 1
+         GPU: 9
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 1
 
-            GPU: 10
-                PARTITION:
-                    ACCELERATOR_PARTITION: N/A
-                    MEMORY_PARTITION: N/A
-                    PARTITION_ID: 2
-            ...
+         GPU: 10
+             PARTITION:
+                 ACCELERATOR_PARTITION: N/A
+                 MEMORY_PARTITION: N/A
+                 PARTITION_ID: 2
+         ...
 
 3. Modifying Partitions
 ------------------------
 
-    - This section describes how to modify the partitioning modes of MI300X GPUs using the `amd-smi` tool.
+    - This section describes how to modify the partitioning modes of MI300X GPUs using the ``amd-smi`` tool.
     - You can switch between compute and memory partitioning modes as needed.
     - The example below demonstrates how to switch between compute and memory partitioning modes.
 
@@ -263,93 +263,93 @@ Use the following commands to switch compute or memory partitioning modes.
 
 **Compute Partition Examples:**
 
-   .. tab-set::
+.. tab-set::
 
-      .. tab-item:: Compute Partition Command
+   .. tab-item:: Compute Partition Command
 
-         .. code-block:: shell-session
+      .. code-block:: shell
 
-            # Set compute partition mode
-            sudo amd-smi set --gpu all --compute-partition CPX    
+         # Set compute partition mode
+         sudo amd-smi set --gpu all --compute-partition CPX
 
-      .. tab-item:: Shell output
+   .. tab-item:: Shell output
 
-         ::
+      .. code-block:: shell-session
 
-            GPU: 0
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
+         GPU: 0
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
 
-            GPU: 1
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
+         GPU: 1
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
 
-            GPU: 2
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
+         GPU: 2
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
 
-            GPU: 3
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
+         GPU: 3
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
 
-            GPU: 4
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
+         GPU: 4
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
 
-            GPU: 5
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
+         GPU: 5
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
 
-            GPU: 6
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
+         GPU: 6
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
 
-            GPU: 7
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
- 
-   .. tab-set::
+         GPU: 7
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to CPX (profile #3)
 
-      .. tab-item:: Compute Partition Command
+.. tab-set::
 
-         .. code-block:: shell-session
+   .. tab-item:: Compute Partition Command
 
-            # Set compute partition mode
-            sudo amd-smi set --gpu all --compute-partition SPX    
+      .. code-block:: shell
 
-      .. tab-item:: Shell output
+         # Set compute partition mode
+         sudo amd-smi set --gpu all --compute-partition SPX
 
-         ::
+   .. tab-item:: Shell output
 
-            GPU: 0
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
+      .. code-block:: shell-session
 
-            GPU: 1
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
+         GPU: 0
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
 
-            GPU: 2
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
+         GPU: 1
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
 
-            GPU: 3
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
+         GPU: 2
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
 
-            GPU: 4
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
+         GPU: 3
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
 
-            GPU: 5
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
+         GPU: 4
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
 
-            GPU: 6
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
+         GPU: 5
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
 
-            GPU: 7
-                ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
+         GPU: 6
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
 
-   .. tab-set::
+         GPU: 7
+             ACCELERATOR_PARTITION: Successfully set accelerator partition to SPX (profile #0)
 
-      .. tab-item:: Memory Partition Command
+.. tab-set::
 
-         .. code-block:: shell-session
+   .. tab-item:: Memory Partition Command
 
-            # Set memory partition mode
-            sudo amd-smi set --memory-partition NPS4  
+      .. code-block:: shell
 
-      .. tab-item:: Shell output
+         # Set memory partition mode
+         sudo amd-smi set --memory-partition NPS4
 
-         ::
-            
+   .. tab-item:: Shell output
+
+      .. code-block:: shell-session
+
           ****** WARNING ******
 
           Setting Dynamic Memory (NPS) partition modes require users to quit all GPU workloads.
@@ -410,19 +410,19 @@ Use the following commands to switch compute or memory partitioning modes.
 
           OSError: [Errno 24] Too many open files
 
-   .. tab-set::
+.. tab-set::
 
-      .. tab-item:: Memory Partition Command
+   .. tab-item:: Memory Partition Command
 
-         .. code-block:: shell-session
+      .. code-block:: shell
 
-            # Set memory partition mode
-            sudo amd-smi set --memory-partition NPS1  
+         # Set memory partition mode
+         sudo amd-smi set --memory-partition NPS1
 
-      .. tab-item:: Shell output
+   .. tab-item:: Shell output
 
-         ::
-            
+      .. code-block:: shell-session
+
           ****** WARNING ******
 
           Setting Dynamic Memory (NPS) partition modes require users to quit all GPU workloads.
@@ -462,18 +462,19 @@ Use the following commands to switch compute or memory partitioning modes.
                 MEMORY_PARTITION: Successfully set memory partition to NPS1
 
 .. note:
-      NPS4 is only compatible with CPX mode. Attempting to set NPS4 with SPX will result in a failure.
+
+   NPS4 is only compatible with CPX mode. Attempting to set NPS4 with SPX will result in a failure.
 
 4. Deleting Partitions
 -----------------------
 
-    - This section describes how to delete or reset the partitioning modes of MI300X GPUs using the `amd-smi` tool.
+    - This section describes how to delete or reset the partitioning modes of MI300X GPUs using the ``amd-smi`` tool.
     - You can revert the partitioning modes to their default settings.
     - The example below demonstrates how to delete or reset the partitioning modes.
 
 To delete or reset partitions, revert both compute and memory partitioning to defaults:
 
-.. code-block:: shell-session
+.. code-block:: shell
 
    sudo amd-smi set --gpu all --compute-partition SPX
    sudo amd-smi set --memory-partition NPS1

--- a/docs/gpu-partitioning/mi300x/quick-start-guide.rst
+++ b/docs/gpu-partitioning/mi300x/quick-start-guide.rst
@@ -183,391 +183,74 @@ Use `amd-smi` to confirm active partition states:
 
       .. tab-item:: Shell output
 
-         ::
+         .. code-block:: shell-session
 
             GPU: 0
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: CPX
+                    MEMORY_PARTITION: NPS1
                     PARTITION_ID: 0
 
             GPU: 1
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 1
 
             GPU: 2
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 2
 
             GPU: 3
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 3
 
             GPU: 4
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 4
 
             GPU: 5
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 5
 
             GPU: 6
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 6
 
             GPU: 7
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 7
-            
+
             GPU: 8
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: CPX
+                    MEMORY_PARTITION: NPS1
                     PARTITION_ID: 0
 
             GPU: 9
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 1
 
             GPU: 10
                 PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
+                    ACCELERATOR_PARTITION: N/A
+                    MEMORY_PARTITION: N/A
                     PARTITION_ID: 2
-
-            GPU: 11
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 3
-
-            GPU: 12
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 4
-
-            GPU: 13
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 5
-
-            GPU: 14
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 6
-
-            GPU: 15
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 7
-            
-            GPU: 16
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 0
-
-            GPU: 17
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 1
-
-            GPU: 18
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 2
-
-            GPU: 19
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 3
-
-            GPU: 20
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 4
-
-            GPU: 21
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 5
-
-            GPU: 22
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 6
-
-            GPU: 23
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 7
-            
-            GPU: 24
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 0
-
-            GPU: 25
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 1
-
-            GPU: 26
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 2
-
-            GPU: 27
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 3
-
-            GPU: 28
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 4
-
-            GPU: 29
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 5
-
-            GPU: 30
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 6
-
-            GPU: 31
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 7
-            
-            GPU: 32
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 0
-
-            GPU: 33
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 1
-
-            GPU: 34
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 2
-
-            GPU: 35
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 3
-
-            GPU: 36
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 4
-
-            GPU: 37
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 5
-
-            GPU: 38
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 6
-
-            GPU: 39
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 7
-            
-            GPU: 40
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 0
-
-            GPU: 41
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 1
-
-            GPU: 42
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 2
-
-            GPU: 43
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 3
-
-            GPU: 44
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 4
-
-            GPU: 45
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 5
-
-            GPU: 46
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 6
-
-            GPU: 47
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 7
-            
-            GPU: 48
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 0
-
-            GPU: 49
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 1
-
-            GPU: 50
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 2
-
-            GPU: 51
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 3
-
-            GPU: 52
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 4
-
-            GPU: 53
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 5
-
-            GPU: 54
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 6
-
-            GPU: 55
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 7
-            
-            GPU: 56
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 0
-
-            GPU: 57
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 1
-
-            GPU: 58
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 2
-
-            GPU: 59
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 3
-
-            GPU: 60
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 4
-
-            GPU: 61
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 5
-
-            GPU: 62
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 6
-
-            GPU: 63
-                PARTITION:
-                    COMPUTE_PARTITION: CPX
-                    MEMORY_PARTITION: NPS4
-                    PARTITION_ID: 7
+            ...
 
 3. Modifying Partitions
 ------------------------

--- a/docs/gpu-partitioning/mi300x/quick-start-guide.rst
+++ b/docs/gpu-partitioning/mi300x/quick-start-guide.rst
@@ -250,6 +250,12 @@ Use ``amd-smi`` to confirm active partition states:
                  PARTITION_ID: 2
          ...
 
+      .. note::
+
+         Recently created partitions will display N/A for their partition
+         information. This is to be expected for security reasons and will be
+         addressed in a later feature update to ``amd-smi``.
+
 3. Modifying Partitions
 ------------------------
 


### PR DESCRIPTION
## Motivation

Update shell output under "Verifying Partition Creation" https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/gpu-partitioning/mi300x/quick-start-guide.html#verifying-partition-creation

It currently displays all partition information which is not the current behavior.

Main change: https://github.com/ROCm/amdgpu-docs/pull/36/commits/1512eb0960c2431cc94b7d0529fbcb88ab3b9266 https://github.com/ROCm/amdgpu-docs/pull/36/commits/ae78279758fceeb7c38f142ef037e803a741e67f
Other changes to clean up indentation and extra white space

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
