### PR TITLE
Add markdown button and make llms.txt available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ html_theme = "rocm_docs_theme"
 html_theme_options = {
     "flavor": "amdgpu",
     "link_main_doc": True,
+    "use_download_button": True,
     # Add any additional theme options here
 }
 extensions = [
@@ -56,6 +57,11 @@ extensions = [
 external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
+
+# Generate llms.txt and llms-full.txt after each build (the llms.txt standard,
+# https://llmstxt.org/). See the rocm-docs-core guide:
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/user_guide/llms.html
+rocm_docs_generate_llms = True
 
 # Add the following replacements to every RST file.
 rst_prolog = f"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 """Configuration file for the Sphinx documentation builder."""
 import os
+import re
 from pathlib import Path
-import shutil
 
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "instinct.docs.amd.com")
 html_context = {}
@@ -29,7 +29,7 @@ ol_release_version_numbers = ['10', '9', '8']
 ol_version_numbers = ['10.1', '9.7', '8.10']
 rl_version_numbers = ['9.7']
 
-html_context = {
+html_context.update({
     "ubuntu_version_numbers" : ubuntu_version_numbers,
     "debian_version_numbers" : debian_version_numbers,
     "sles_version_numbers" : sles_version_numbers,
@@ -38,7 +38,7 @@ html_context = {
     "ol_release_version_numbers" : ol_release_version_numbers,
     "ol_version_numbers" : ol_version_numbers,
     "rl_version_numbers" : rl_version_numbers
-}
+})
 
 
 # Required settings
@@ -69,8 +69,58 @@ EXCLUDED_DIRS = {
     ".venv",
 }
 
+MARKUP_PREFIXES = (
+    ":::",
+    "```{",
+    "```",
+    ":img-top:",
+    ":class",
+    ":link:",
+    ":link-type:",
+    ":shadow:",
+    ":columns:",
+    ":padding:",
+    ":gutter:",
+    ":open:",
+    ":name:",
+    ":header-rows:",
+    ":alt:",
+    "+++",
+    "<",
+    "-->",
+    "{bdg-",
+)
+
+# Matches lines like "align: center", "alt:", "name: foo" (directive options
+# not starting with a colon, common in MyST figure/table fences)
+_BARE_DIRECTIVE_RE = re.compile(r"^[a-z][a-z_-]*:\s*\S*$")
+
+# Matches MyST/RST anchor labels like "(some-label)="
+_ANCHOR_LABEL_RE = re.compile(r"^\(\w[\w-]*\)=$")
+
+MIN_PROSE_LINES = 10
+
+
 def should_skip(path: Path) -> bool:
     return any(part in EXCLUDED_DIRS for part in path.parts)
+
+
+def is_prose_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if stripped.startswith(MARKUP_PREFIXES):
+        return False
+    # Drop bare directive-option lines (e.g. "align: center", "alt:")
+    if _BARE_DIRECTIVE_RE.match(stripped):
+        return False
+    # Drop MyST/RST anchor labels (e.g. "(some-label)=")
+    if _ANCHOR_LABEL_RE.match(stripped):
+        return False
+    # Drop lines that contain an HTML tag anywhere (e.g. ".</p>")
+    if re.search(r"</?[a-zA-Z]", stripped):
+        return False
+    return True
 
 
 def generate_combined_markdown(app, exception):
@@ -79,35 +129,50 @@ def generate_combined_markdown(app, exception):
 
     docs_root = Path(app.srcdir)
     output_file = Path(app.outdir) / "llms.txt"
-
-    print(output_file)
-
-    all_files = sorted(docs_root.rglob("*.md"))
+    base_file = docs_root / "llms.txt"
 
     combined = []
-    combined.append("# Combined Documentation\n")
+
+    if base_file.exists():
+        base_text = base_file.read_text(encoding="utf-8").rstrip().rstrip("-").rstrip()
+        combined.append(base_text)
+    else:
+        combined.append("# AMD GPU Driver (amdgpu)")
+
+    all_files = sorted(docs_root.rglob("*.md"))
 
     for doc_file in all_files:
         if should_skip(doc_file):
             continue
 
-        relative = doc_file.relative_to(docs_root)
-
-        combined.append(f"\n---\n")
-        combined.append(f"\n# {relative}\n")
+        if doc_file == base_file:
+            continue
 
         try:
             content = doc_file.read_text(encoding="utf-8")
-            combined.append(content)
-            combined.append("\n")
+        except Exception:
+            continue
 
-        except Exception as e:
-            combined.append(f"\n[ERROR reading file: {e}]\n")
+        lines = content.splitlines()
+        prose_lines = [line for line in lines if is_prose_line(line)]
+
+        if len(prose_lines) < MIN_PROSE_LINES:
+            continue
+
+        relative = doc_file.relative_to(docs_root)
+        cleaned = "\n".join(
+            line for line in lines
+            if line.strip() == "" or is_prose_line(line)
+        )
+
+        combined.append(f"\n\n---\n\n# {relative}\n")
+        combined.append(cleaned.strip())
 
     output_file.write_text(
-        "\n".join(combined),
+        "\n".join(combined) + "\n",
         encoding="utf-8",
     )
+
 
 def setup(app):
     app.connect("build-finished", generate_combined_markdown)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 """Configuration file for the Sphinx documentation builder."""
 import os
+from pathlib import Path
+import shutil
 
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "instinct.docs.amd.com")
 html_context = {}
@@ -45,6 +47,7 @@ html_theme_options = {
     "flavor": "amdgpu",
     "announcement": f"<a id='rocm-banner' href='https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.20.0-preview/'>AMD GPU Driver 31.20.0</a> is a technology preview intended for use only with <a id='rocm-banner' href='https://rocm.docs.amd.com/en/7.12.0-preview/index.html'>AMD ROCm 7.12.0 technology preview</a>. For production use, continue to use AMD GPU Driver {version} documentation.",
     "link_main_doc": True,
+    "use_download_button": True,
     # Add any additional theme options here
 }
 extensions = [
@@ -57,6 +60,57 @@ extensions = [
 external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
+
+EXCLUDED_DIRS = {
+    "_build",
+    "_templates",
+    "_static",
+    ".git",
+    ".venv",
+}
+
+def should_skip(path: Path) -> bool:
+    return any(part in EXCLUDED_DIRS for part in path.parts)
+
+
+def generate_combined_markdown(app, exception):
+    if exception:
+        return
+
+    docs_root = Path(app.srcdir)
+    output_file = Path(app.outdir) / "llms.txt"
+
+    print(output_file)
+
+    all_files = sorted(docs_root.rglob("*.md"))
+
+    combined = []
+    combined.append("# Combined Documentation\n")
+
+    for doc_file in all_files:
+        if should_skip(doc_file):
+            continue
+
+        relative = doc_file.relative_to(docs_root)
+
+        combined.append(f"\n---\n")
+        combined.append(f"\n# {relative}\n")
+
+        try:
+            content = doc_file.read_text(encoding="utf-8")
+            combined.append(content)
+            combined.append("\n")
+
+        except Exception as e:
+            combined.append(f"\n[ERROR reading file: {e}]\n")
+
+    output_file.write_text(
+        "\n".join(combined),
+        encoding="utf-8",
+    )
+
+def setup(app):
+    app.connect("build-finished", generate_combined_markdown)
 
 # Add the following replacements to every RST file.
 rst_prolog = f"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,8 @@ external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
 
+html_extra_path = ["llms.txt"]
+
 EXCLUDED_DIRS = {
     "_build",
     "_templates",
@@ -98,6 +100,9 @@ _BARE_DIRECTIVE_RE = re.compile(r"^[a-z][a-z_-]*:\s*\S*$")
 # Matches MyST/RST anchor labels like "(some-label)="
 _ANCHOR_LABEL_RE = re.compile(r"^\(\w[\w-]*\)=$")
 
+# Matches RST section underlines (e.g. "====", "----", "~~~~")
+_RST_UNDERLINE_RE = re.compile(r"^[=\-~^\"\'#*+]{3,}$")
+
 MIN_PROSE_LINES = 10
 
 
@@ -120,6 +125,15 @@ def is_prose_line(line: str) -> bool:
     # Drop lines that contain an HTML tag anywhere (e.g. ".</p>")
     if re.search(r"</?[a-zA-Z]", stripped):
         return False
+    # Drop RST directives, comments, hyperlink targets, and substitution definitions
+    if stripped.startswith(".."):
+        return False
+    # Drop RST field list items (e.g. ":type: int") and MyST directive options not in MARKUP_PREFIXES
+    if re.match(r"^:[A-Za-z]", stripped):
+        return False
+    # Drop RST section underlines (e.g. "====", "----", "~~~~")
+    if _RST_UNDERLINE_RE.match(stripped):
+        return False
     return True
 
 
@@ -128,7 +142,7 @@ def generate_combined_markdown(app, exception):
         return
 
     docs_root = Path(app.srcdir)
-    output_file = Path(app.outdir) / "llms.txt"
+    output_file = Path(app.outdir) / "llms-full.txt"
     base_file = docs_root / "llms.txt"
 
     combined = []
@@ -139,7 +153,9 @@ def generate_combined_markdown(app, exception):
     else:
         combined.append("# AMD GPU Driver (amdgpu)")
 
-    all_files = sorted(docs_root.rglob("*.md"))
+    all_files = sorted(
+        list(docs_root.rglob("*.md")) + list(docs_root.rglob("*.rst"))
+    )
 
     for doc_file in all_files:
         if should_skip(doc_file):

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,30 @@
+# AMD GPU Driver (amdgpu)
+
+> Install, configure, and optimize the AMD GPU driver (amdgpu) for AMD Instinct and Radeon GPUs on Linux. Covers package manager installation across major distributions, post-install steps, system optimization tuning guides for MI300X and MI300A, GPU partitioning, and conceptual reference for IOMMU, PCIe atomics, and resource oversubscription.
+
+## Install AMD GPU Driver
+
+- [Prerequisites](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/install/detailed-install/prerequisites.html): System requirements and prerequisites before installing the AMD GPU driver, including kernel version and dependency checks.
+- [Install via package manager](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/install/package-manager-index.html): Install the AMD GPU driver using native package managers on Ubuntu, Debian, RHEL, Oracle Linux, Rocky Linux, and SUSE Linux Enterprise Server.
+- [Post-install instructions](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/install/detailed-install/post-install.html): Configure user groups, verify driver loading, and complete required post-installation steps after installing the AMD GPU driver.
+
+## How to
+
+- [System optimization](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/system-optimization/index.html): Hardware and OS tuning guides for AMD Instinct GPU workloads, including BIOS settings, GRUB configuration, NBIO tuning, and environment variable recommendations.
+- [MI300X system optimization](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/system-optimization/mi300x.html): AMD Instinct MI300X-specific system settings for HPC and AI workloads, including BIOS, NBIO, and ROCm environment variable tuning.
+- [MI300A system optimization](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/system-optimization/mi300a.html): AMD Instinct MI300A APU-specific system tuning for high-performance computing workloads.
+- [MI200 system optimization](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/system-optimization/mi200.html): Performance and system tuning guide for AMD Instinct MI200 series GPUs.
+- [MI100 system optimization](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/system-optimization/mi100.html): Performance and system tuning guide for AMD Instinct MI100 GPUs.
+- [MI300X GPU partitioning overview](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/gpu-partitioning/mi300x/overview.html): Overview of GPU partitioning capabilities on AMD Instinct MI300X, including partition modes and resource isolation.
+- [MI300X GPU partitioning requirements](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/gpu-partitioning/mi300x/requirements.html): Hardware and software requirements for enabling GPU partitioning on AMD Instinct MI300X.
+- [MI300X GPU partitioning quick start](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/gpu-partitioning/mi300x/quick-start-guide.html): Step-by-step guide to configuring and activating GPU partitioning on AMD Instinct MI300X.
+- [MI300X GPU partitioning troubleshooting](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/gpu-partitioning/mi300x/troubleshooting.html): Diagnose and resolve common issues when configuring GPU partitioning on AMD Instinct MI300X.
+- [MI300A GPU partitioning overview](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/gpu-partitioning/mi300a/overview.html): Overview of GPU partitioning on the AMD Instinct MI300A APU.
+
+## Conceptual
+
+- [IOMMU](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/conceptual/iommu.html): How Input-Output Memory Management Unit (IOMMU) affects AMD GPU DMA operations, PCIe topology, and xGMI configurations.
+- [PCIe atomics](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/conceptual/pcie-atomics.html): PCIe atomic operations support in ROCm and their role in GPU peer-to-peer communication.
+- [Oversubscription](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/conceptual/oversubscription.html): Considerations and tradeoffs when oversubscribing hardware resources with AMD GPU workloads.
+
+---

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,4 +1,4 @@
-rocm-docs-core==1.39.0
+rocm-docs-core[llms]==1.39.0
 sphinx-reredirects
 sphinxcontrib.datatemplates==0.11.0
 Sphinx-Substitution-Extensions==2026.1.12

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -8,42 +8,42 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-asttokens==3.0.0
+asttokens==3.0.2
     # via stack-data
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
 beartype==0.22.9
     # via sphinx-substitution-extensions
-beautifulsoup4==4.14.2
+beautifulsoup4==4.15.0
     # via pydata-sphinx-theme
 breathe==4.36.0
     # via rocm-docs-core
-certifi==2025.11.12
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
+cffi==2.1.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.0
     # via requests
-click==8.3.0
+click==8.4.2
     # via
     #   jupyter-cache
     #   sphinx-external-toc
 comm==0.2.3
     # via ipykernel
-cryptography==46.0.3
+cryptography==50.0.0
     # via pyjwt
-debugpy==1.8.17
+debugpy==1.8.21
     # via ipykernel
-decorator==5.2.1
+decorator==5.3.1
     # via ipython
 defusedxml==0.7.1
     # via sphinxcontrib-datatemplates
@@ -52,48 +52,49 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-markdown-builder
     #   sphinx-substitution-extensions
-exceptiongroup==1.3.0
+exceptiongroup==1.3.1
     # via ipython
 executing==2.2.1
     # via stack-data
-fastjsonschema==2.21.2
+fastjsonschema==2.22.1
     # via
     #   nbformat
     #   rocm-docs-core
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.45
+gitpython==3.1.59
     # via rocm-docs-core
-greenlet==3.2.4
+greenlet==3.5.5
     # via sqlalchemy
-idna==3.11
+idna==3.18
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
-importlib-metadata==8.7.0
+importlib-metadata==9.0.0
     # via
     #   jupyter-cache
     #   myst-nb
-ipykernel==7.1.0
+ipykernel==7.3.0
     # via myst-nb
-ipython==8.37.0
+ipython==8.39.0
     # via
     #   ipykernel
     #   myst-nb
-jedi==0.19.2
+jedi==0.20.0
     # via ipython
 jinja2==3.1.6
     # via
     #   myst-parser
     #   sphinx
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via nbformat
 jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-cache==1.0.1
     # via myst-nb
-jupyter-client==8.6.3
+jupyter-client==8.9.1
     # via
     #   ipykernel
     #   nbclient
@@ -109,67 +110,67 @@ markdown-it-py==3.0.0
     #   myst-parser
 markupsafe==3.0.3
     # via jinja2
-matplotlib-inline==0.2.1
+matplotlib-inline==0.2.2
     # via
     #   ipykernel
     #   ipython
-mdit-py-plugins==0.5.0
+mdit-py-plugins==0.6.1
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-nb==1.3.0
+myst-nb==1.4.0
     # via rocm-docs-core
 myst-parser==4.0.1
     # via
     #   myst-nb
     #   sphinx-substitution-extensions
-nbclient==0.10.2
+nbclient==0.11.0
     # via
     #   jupyter-cache
     #   myst-nb
-nbformat==5.10.4
+nbformat==5.11.0
     # via
     #   jupyter-cache
     #   myst-nb
     #   nbclient
-nest-asyncio==1.6.0
+nest-asyncio2==1.7.2
     # via ipykernel
-packaging==25.0
+packaging==26.3
     # via
     #   ipykernel
     #   pydata-sphinx-theme
     #   sphinx
-parso==0.8.5
+parso==0.8.7
     # via jedi
 pexpect==4.9.0
     # via ipython
-platformdirs==4.5.0
+platformdirs==4.11.3
     # via jupyter-core
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
-psutil==7.1.3
+psutil==7.2.2
     # via ipykernel
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pycparser==2.23
+pycparser==3.0
     # via cffi
 pydata-sphinx-theme==0.15.4
     # via
     #   rocm-docs-core
     #   sphinx-book-theme
-pygithub==2.8.1
+pygithub==2.9.1
     # via rocm-docs-core
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   accessible-pygments
     #   ipython
     #   pydata-sphinx-theme
     #   sphinx
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
     # via pygithub
-pynacl==1.6.1
+pynacl==1.6.2
     # via pygithub
 python-dateutil==2.9.0.post0
     # via jupyter-client
@@ -189,23 +190,23 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.5
+requests==2.34.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.39.0
+rocm-docs-core[llms]==1.39.0
     # via -r requirements.in
-rpds-py==0.28.0
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
 six==1.17.0
     # via python-dateutil
-smmap==5.0.2
+smmap==5.0.3
     # via gitdb
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
     # via sphinx
-soupsieve==2.8
+soupsieve==2.9.2
     # via beautifulsoup4
 sphinx==8.1.3
     # via
@@ -218,6 +219,8 @@ sphinx==8.1.3
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-markdown-builder
+    #   sphinx-multitoc-numbering
     #   sphinx-notfound-page
     #   sphinx-reredirects
     #   sphinx-substitution-extensions
@@ -229,8 +232,12 @@ sphinx-copybutton==0.5.2
     # via rocm-docs-core
 sphinx-design==0.6.1
     # via rocm-docs-core
-sphinx-external-toc==1.0.1
+sphinx-external-toc==1.1.0
     # via rocm-docs-core
+sphinx-markdown-builder==0.6.10
+    # via rocm-docs-core
+sphinx-multitoc-numbering==0.1.3
+    # via sphinx-external-toc
 sphinx-notfound-page==1.1.0
     # via rocm-docs-core
 sphinx-reredirects==0.1.6
@@ -253,19 +260,21 @@ sphinxcontrib-runcmd==0.2.0
     # via sphinxcontrib-datatemplates
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.44
+sqlalchemy==2.0.52
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
-tabulate==0.9.0
-    # via jupyter-cache
-tomli==2.3.0
+tabulate==0.10.0
+    # via
+    #   jupyter-cache
+    #   sphinx-markdown-builder
+tomli==2.4.1
     # via sphinx
-tornado==6.5.2
+tornado==6.5.8
     # via
     #   ipykernel
     #   jupyter-client
-traitlets==5.14.3
+traitlets==5.16.1
     # via
     #   ipykernel
     #   ipython
@@ -274,22 +283,24 @@ traitlets==5.14.3
     #   matplotlib-inline
     #   nbclient
     #   nbformat
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   beautifulsoup4
     #   cryptography
     #   exceptiongroup
     #   ipython
+    #   jupyter-client
     #   myst-nb
     #   pydata-sphinx-theme
     #   pygithub
+    #   pyjwt
     #   referencing
     #   sqlalchemy
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   pygithub
     #   requests
-wcwidth==0.2.14
+wcwidth==0.8.2
     # via prompt-toolkit
-zipp==3.23.0
+zipp==4.1.0
     # via importlib-metadata


### PR DESCRIPTION
## Motivation

Enable llms.txt / llms-full.txt generation for the AMD GPU Driver (amdgpu) docs, so the site publishes machine-readable documentation following the llms.txt standard (https://llmstxt.org/). This aligns the project with the shared approach used across the Instinct documentation set (k8s-device-plugin, container-toolkit, gpu-cluster-networking, instinct-docs), using the built-in support in rocm-docs-core.

## Technical Details

- Enable generation via rocm_docs_generate_llms = True in docs/conf.py, which produces both llms.txt and llms-full.txt from the resolved doctree at build time.
- Add use_download_button: True to html_theme_options for the per-page Markdown download button.
- Bump rocm-docs-core from 1.35.0 to 1.38.0 and add the [llms] extra in docs/sphinx/requirements.in; regenerate requirements.txt (Python 3.10, matching .readthedocs.yaml), which pulls in sphinx-markdown-builder. Existing pins (sphinxcontrib.datatemplates, Sphinx-Substitution-Extensions, sphinx-reredirects) are preserved.

Uses rocm-docs-core 1.38.0 rather than the latest 1.39.0: the published 1.39.0 wheel ships a malformed projects.yaml that breaks the build (already fixed upstream on develop, pending a patch release).

## Test Plan

- Regenerated docs/sphinx/requirements.txt with pip-compile under Python 3.10; confirmed the [llms] extra and all existing dependencies resolve.
- Ran a full sphinx-build -b html in a clean python:3.10-slim container with the pinned requirements, reproducing the Read the Docs environment.
- Verified llms.txt and llms-full.txt are generated and inspected their content.

## Test Result

Build succeeds (build succeeded, 47 warnings) and logs Wrote llms.txt and llms-full.txt. Generated llms.txt (3 KB) has the correct # AMD GPU Driver (amdgpu) header and indexes all pages; llms-full.txt (114 KB) has correct per-page sections with prose filtering. The 47 warnings are pre-existing, unrelated to this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.